### PR TITLE
add aggregated rates API

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -15,7 +15,9 @@
 
 mod server_api;
 
-use self::server_api::{CompactHandler, ExchangeHandler, IndexHandler, RecentHandler};
+use self::server_api::{
+	AggregateHandler, CompactHandler, ExchangeHandler, IndexHandler, RecentHandler,
+};
 
 use crate::rest::*;
 use crate::router::{Router, RouterError};
@@ -70,12 +72,14 @@ where
 		"/v1/exchange".to_string(),
 		"/v1/recent".to_string(),
 		"/v1/compact".to_string(),
+		"/v1/aggregated".to_string(),
 	];
 
 	let index_handler = IndexHandler { list: route_list };
 	let exchange_handler = ExchangeHandler::new(oracle.clone(), Arc::downgrade(&client));
 	let recent_handler = RecentHandler::new(oracle.clone());
 	let compact_handler = CompactHandler::new(oracle.clone());
+	let aggregated_handler = AggregateHandler::new(oracle.clone());
 
 	let mut router = Router::new();
 
@@ -83,6 +87,7 @@ where
 	router.add_route("/v1/exchange", Arc::new(exchange_handler))?;
 	router.add_route("/v1/recent", Arc::new(recent_handler))?;
 	router.add_route("/v1/compact", Arc::new(compact_handler))?;
+	router.add_route("/v1/aggregated", Arc::new(aggregated_handler))?;
 
 	Ok(router)
 }


### PR DESCRIPTION
Add a new API:
* `/v1/aggregated`

which aggregate the designed 6 currencies exchange rates into one single result, for example:
```sh

$ curl -0 -XGET http://127.0.0.1:3518/v1/aggregated
[
  {
    "from": "USD",
    "to": "EUR",
    "rate": 0.8954,
    "date": "2020-01-06T08:30:00Z"
  },
  {
    "from": "USD",
    "to": "CNY",
    "rate": 6.9743,
    "date": "2020-01-06T08:30:01Z"
  },
  {
    "from": "USD",
    "to": "JPY",
    "rate": 108.02,
    "date": "2020-01-06T08:30:02Z"
  },
  {
    "from": "USD",
    "to": "GBP",
    "rate": 0.7648,
    "date": "2020-01-06T08:30:01Z"
  },
  {
    "from": "USD",
    "to": "CAD",
    "rate": 1.2982,
    "date": "2020-01-06T08:30:01Z"
  },
  {
    "from": "EUR",
    "to": "USD",
    "rate": 1.1168,
    "date": "2020-01-06T08:30:01Z"
  },
  {
    "from": "EUR",
    "to": "CNY",
    "rate": 7.7734,
    "date": "2020-01-06T08:30:03Z"
  },
  {
    "from": "EUR",
    "to": "JPY",
    "rate": 120.63,
    "date": "2020-01-06T08:30:04Z"
  },
  {
    "from": "EUR",
    "to": "GBP",
    "rate": 0.854,
    "date": "2020-01-06T08:30:03Z"
  },
  {
    "from": "EUR",
    "to": "CAD",
    "rate": 1.4497,
    "date": "2020-01-06T08:30:05Z"
  },
  {
    "from": "CNY",
    "to": "USD",
    "rate": 0.1433,
    "date": "2020-01-06T08:30:02Z"
  },
  {
    "from": "CNY",
    "to": "EUR",
    "rate": 0.1284,
    "date": "2020-01-06T08:30:06Z"
  },
  {
    "from": "CNY",
    "to": "JPY",
    "rate": 15.497,
    "date": "2020-01-06T08:30:03Z"
  },
  {
    "from": "CNY",
    "to": "GBP",
    "rate": 0.1096,
    "date": "2020-01-06T08:30:06Z"
  },
  {
    "from": "CNY",
    "to": "CAD",
    "rate": 0.186,
    "date": "2020-01-06T08:30:07Z"
  },
  {
    "from": "JPY",
    "to": "USD",
    "rate": 0.0092,
    "date": "2020-01-06T08:30:03Z"
  },
  {
    "from": "JPY",
    "to": "EUR",
    "rate": 0.0082,
    "date": "2020-01-06T08:30:04Z"
  },
  {
    "from": "JPY",
    "to": "CNY",
    "rate": 0.0645,
    "date": "2020-01-06T08:30:07Z"
  },
  {
    "from": "JPY",
    "to": "GBP",
    "rate": 0.007,
    "date": "2020-01-06T08:30:08Z"
  },
  {
    "from": "JPY",
    "to": "CAD",
    "rate": 0.012,
    "date": "2020-01-06T08:30:08Z"
  },
  {
    "from": "GBP",
    "to": "USD",
    "rate": 1.307,
    "date": "2020-01-06T08:30:01Z"
  },
  {
    "from": "GBP",
    "to": "EUR",
    "rate": 1.1705,
    "date": "2020-01-06T08:30:03Z"
  },
  {
    "from": "GBP",
    "to": "CNY",
    "rate": 9.1163,
    "date": "2020-01-06T08:30:09Z"
  },
  {
    "from": "GBP",
    "to": "JPY",
    "rate": 141.21,
    "date": "2020-01-06T08:30:03Z"
  },
  {
    "from": "GBP",
    "to": "CAD",
    "rate": 1.6972,
    "date": "2020-01-06T08:30:01Z"
  },
  {
    "from": "CAD",
    "to": "USD",
    "rate": 0.7705,
    "date": "2020-01-06T08:30:01Z"
  },
  {
    "from": "CAD",
    "to": "EUR",
    "rate": 0.6899,
    "date": "2020-01-06T08:30:12Z"
  },
  {
    "from": "CAD",
    "to": "CNY",
    "rate": 5.3723,
    "date": "2020-01-06T08:30:12Z"
  },
  {
    "from": "CAD",
    "to": "JPY",
    "rate": 83.254,
    "date": "2020-01-06T08:30:10Z"
  },
  {
    "from": "CAD",
    "to": "GBP",
    "rate": 0.5893,
    "date": "2020-01-06T08:30:12Z"
  },
  {
    "from": "BTC",
    "to": "USD",
    "rate": 7525.0,
    "date": "2020-01-06T08:30:02Z"
  },
  {
    "from": "ETH",
    "to": "USD",
    "rate": 139.33,
    "date": "2020-01-06T08:30:01Z"
  }
]
```