### PR TITLE
query 7 base price pairs instead of 32

### DIFF
--- a/alphavantage/src/exchange_rate.rs
+++ b/alphavantage/src/exchange_rate.rs
@@ -39,6 +39,23 @@ pub struct ExchangeRate {
 	pub date: DateTime<Utc>,
 }
 
+impl Default for ExchangeRate {
+	fn default() -> ExchangeRate {
+		ExchangeRate {
+			from: Currency {
+				name: "NA".to_string(),
+				code: "NA".to_string(),
+			},
+			to: Currency {
+				name: "NA".to_string(),
+				code: "NA".to_string(),
+			},
+			rate: 1f64,
+			date: Utc::now(),
+		}
+	}
+}
+
 /// Represents the exchange rate for a currency pair.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ExchangeRateResult {

--- a/api/src/foreign.rs
+++ b/api/src/foreign.rs
@@ -195,30 +195,24 @@ where
 		let mut rates: Vec<ExchangeRateResult> = oracle.iter().collect();
 		rates.sort_by_key(|rate| std::cmp::Reverse(rate.date.clone()));
 
-		let currencies = vec!["USD", "EUR", "CNY", "JPY", "GBP", "CAD"];
-		let mut aggregated: Vec<ExchangeRateResult> = Vec::new();
-		for from in currencies.clone() {
-			for to in currencies.clone() {
-				if from != to {
-					let index = rates
-						.iter()
-						.position(|r| r.from == from && r.to == to)
-						.ok_or(ErrorKind::NotFound)?;
-					aggregated.push(rates[index].clone());
-				}
-			}
+		let currencies_a = vec!["EUR", "GBP", "BTC", "ETH"];
+		let currencies_b = vec!["CNY", "JPY", "CAD"];
+		let mut aggregated: Vec<ExchangeRateResult> =
+			Vec::with_capacity(currencies_a.len() + currencies_b.len());
+		for from in currencies_a {
+			let index = rates
+				.iter()
+				.position(|r| r.from == from && r.to == "USD")
+				.ok_or(ErrorKind::NotFound)?;
+			aggregated.push(rates[index].clone());
 		}
-
-		let index = rates
-			.iter()
-			.position(|r| r.from == "BTC" && r.to == "USD")
-			.ok_or(ErrorKind::NotFound)?;
-		aggregated.push(rates[index].clone());
-		let index = rates
-			.iter()
-			.position(|r| r.from == "ETH" && r.to == "USD")
-			.ok_or(ErrorKind::NotFound)?;
-		aggregated.push(rates[index].clone());
+		for to in currencies_b {
+			let index = rates
+				.iter()
+				.position(|r| r.from == "USD" && r.to == to)
+				.ok_or(ErrorKind::NotFound)?;
+			aggregated.push(rates[index].clone());
+		}
 
 		Ok(aggregated)
 	}

--- a/api/src/handlers/server_api.rs
+++ b/api/src/handlers/server_api.rs
@@ -259,30 +259,24 @@ where
 		let mut rates: Vec<ExchangeRateResult> = oracle.iter().collect();
 		rates.sort_by_key(|rate| std::cmp::Reverse(rate.date.clone()));
 
-		let currencies = vec!["USD", "EUR", "CNY", "JPY", "GBP", "CAD"];
-		let mut aggregated: Vec<ExchangeRateResult> = Vec::new();
-		for from in currencies.clone() {
-			for to in currencies.clone() {
-				if from != to {
-					let index = rates
-						.iter()
-						.position(|r| r.from == from && r.to == to)
-						.ok_or(ErrorKind::NotFound)?;
-					aggregated.push(rates[index].clone());
-				}
-			}
+		let currencies_a = vec!["EUR", "GBP", "BTC", "ETH"];
+		let currencies_b = vec!["CNY", "JPY", "CAD"];
+		let mut aggregated: Vec<ExchangeRateResult> =
+			Vec::with_capacity(currencies_a.len() + currencies_b.len());
+		for from in currencies_a {
+			let index = rates
+				.iter()
+				.position(|r| r.from == from && r.to == "USD")
+				.ok_or(ErrorKind::NotFound)?;
+			aggregated.push(rates[index].clone());
 		}
-
-		let index = rates
-			.iter()
-			.position(|r| r.from == "BTC" && r.to == "USD")
-			.ok_or(ErrorKind::NotFound)?;
-		aggregated.push(rates[index].clone());
-		let index = rates
-			.iter()
-			.position(|r| r.from == "ETH" && r.to == "USD")
-			.ok_or(ErrorKind::NotFound)?;
-		aggregated.push(rates[index].clone());
+		for to in currencies_b {
+			let index = rates
+				.iter()
+				.position(|r| r.from == "USD" && r.to == to)
+				.ok_or(ErrorKind::NotFound)?;
+			aggregated.push(rates[index].clone());
+		}
 
 		Ok(aggregated)
 	}


### PR DESCRIPTION
See https://github.com/gottstech/gotts/wiki/Gotts-Stable-Coins#4-currency-pairs-vs-trading-pairs for the detail, query 7 base "price pairs" instead of each pair.
